### PR TITLE
Make detect platform.cpu work on MacOS

### DIFF
--- a/module/platform.cpu/module.py
+++ b/module/platform.cpu/module.py
@@ -488,8 +488,6 @@ def detect(i):
 
     elif mac=='yes':
       r=ck.run_and_get_stdout({'cmd': ['sysctl', 'machdep.cpu', 'hw.cpufrequency']})
-      # import pprint
-      # pprint.pprint(r)
       if r['return']>0: return r
       
       info_cpu={}


### PR DESCRIPTION
Hi,

This PR makes the `ck detect platform.cpu` command work on OS X. 

**!!! This PR depends on this kernel PR https://github.com/ctuning/ck/pull/51 and will not work without it !!!**

Before the patch, the command returns the following:

    $ ck detect platform.cpu
    cat: /etc/*-release: No such file or directory
    
    OS CK UOA:         macos-64 (fb7d7f63b44b9ea3)
    
    OS name:           
    Short OS name:     Darwin 15.6.0
    Long OS name:      Darwin-15.6.0-x86_64-i386-64bit
    OS bits:           64
    
    Platform init UOA: -
    CK error: problem opening text file=/proc/cpuinfo ([Errno 2] No such file or directory: '/proc/cpuinfo')!

After the patch, the command returns the following:

    $ ck detect platform.cpu
    cat: /etc/*-release: No such file or directory
    
    OS CK UOA:         macos-64 (fb7d7f63b44b9ea3)
    
    OS name:           
    Short OS name:     Darwin 15.6.0
    Long OS name:      Darwin-15.6.0-x86_64-i386-64bit
    OS bits:           64
    
    Platform init UOA: -
    
    Number of logical processors: 4
    CPU name:                     Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz
    CPU ABI:                      
    CPU features:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clfsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 mon dscpl vmx est tm2 ssse3 fma cx16 tpr pdcm sse4.1 sse4.2 x2apic movbe popcnt aes pcid xsave osxsave seglim64 tsctmr avx1.0 rdrand f16c
    
    CPU frequency:
      CPU0 = 2600 MHz
    CPU max frequency:
      CPU0 = 2600 MHz

This PR does not completely fix issue #7, but it's the first step. 