### PR TITLE
GPU and platform detection

### DIFF
--- a/module/platform/module.py
+++ b/module/platform/module.py
@@ -183,6 +183,7 @@ def detect(i):
 
     remote=os_dict.get('remote','')
     os_win=os_dict.get('windows_base','')
+    os_mac=os_dict.get('macos','')
 
     ro=os_dict.get('redirect_stdout','')
 
@@ -299,6 +300,26 @@ def detect(i):
           target_system_model=r['value']
 
           prop_all['cs_product']=info1
+       elif os_mac=='yes':
+          if getattr(ck, 'run_and_get_stdout', None)==None:
+             return {'return':1, 'error':'your CK kernel is outdated (function run_and_get_stdout not found) - please, update it!'}
+
+          r=ck.run_and_get_stdout({'cmd': ['system_profiler', 'SPHardwareDataType']})
+          if r['return']>0: return r
+
+          x1='Apple Inc.'
+
+          for line in r['stdout'].splitlines():
+            if ':' in line:
+              left, right = line.split(':', 1)
+              left = left.strip().lower()
+              if left == 'model name':
+                target_name = right.strip()
+              if left == 'model identifier':
+                target_system_model = right.strip()
+              if target_name!='' and target_system_model!='':
+                break
+
        else:
           file_with_vendor='/sys/devices/virtual/dmi/id/sys_vendor'
           if os.path.isfile(file_with_vendor):


### PR DESCRIPTION
Hi,

This PR adds GPU and platform detection for Mac OS. With it, the `ck detect platform` command outputs something like this:

```
$ ck detect platform
***************************************************************************************
Detecting OS and CPU features ...
cat: /etc/*-release: No such file or directory

OS CK UOA:         macos-64 (fb7d7f63b44b9ea3)

OS name:           Darwin 15.6.0
Short OS name:     Darwin 15.6.0
Long OS name:      Darwin-15.6.0-x86_64-i386-64bit
OS bits:           64

Platform init UOA: -

Number of logical processors: 4
CPU name:                     Intel(R) Core(TM) i5-4278U CPU @ 2.60GHz
CPU ABI:                      
CPU features:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clfsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 mon dscpl vmx est tm2 ssse3 fma cx16 tpr pdcm sse4.1 sse4.2 x2apic movbe popcnt aes pcid xsave osxsave seglim64 tsctmr avx1.0 rdrand f16c

CPU frequency:
  CPU0 = 2600 MHz
CPU max frequency:
  CPU0 = 2600 MHz
***************************************************************************************
Detecting GPU features ...
cat: /etc/*-release: No such file or directory

GPU name:   Intel Iris
GPU vendor: Intel
***************************************************************************************
Detecting system features ...

Platform name:   MacBook Pro (MacBookPro11,1)
Platform vendor: Apple Inc.
Platform model:  MacBookPro11,1
```

(fields GPU name, GPU vendor, Platform name/vendor/model are filled). 

With `Platform vendor`, I simply hardcoded `Apple Inc.`, as I didn't find a way to get this info. I think, it's a fairly safe assumption. Other fields are filled with real values.

This PR should fix #7.