### PR TITLE
Detect pretty OS name for Mac OS

### DIFF
--- a/module/platform.os/module.py
+++ b/module/platform.os/module.py
@@ -140,6 +140,7 @@ def detect(i):
 
     remote=tosd.get('remote','')
     win=tosd.get('windows_base','')
+    mac=tosd.get('macos','')
 
     # Init params
     prop={}
@@ -343,6 +344,19 @@ def detect(i):
                             prop_os_name_long='Windows-'+s0
 
              prop_os_name=prop_os_name_short
+
+          elif mac=='yes' and getattr(ck, 'run_and_get_stdout', None)!=None:
+            r=ck.run_and_get_stdout({'cmd': ['sw_vers']})
+            if r['return']==0:
+              sw_vers={}
+              for line in r['stdout'].splitlines():
+                if ':' in line:
+                  left, right = line.split(':', 1)
+                  left = left.strip()
+                  right = right.strip()
+                  sw_vers[left]=right
+
+              prop_os_name=sw_vers.get('ProductName', '') + ' ' + sw_vers.get('ProductVersion', '')
 
           else:
              # If Linux, remove extensions after - in a shorter version


### PR DESCRIPTION
Hi,

This PR fills 'OS Name' with a pretty value like 'Mac OS X 10.11.6' for Mac OS. Other values are not changed. With it, the output of `ck detect platform.os` looks like this:

```
$ ck detect platform.os

OS CK UOA:         macos-64 (fb7d7f63b44b9ea3)

OS name:           Mac OS X 10.11.6
Short OS name:     Darwin 15.6.0
Long OS name:      Darwin-15.6.0-x86_64-i386-64bit
OS bits:           64

Platform init UOA: -
```

(previously, 'OS name' was equal to 'Short OS name')