### PR TITLE
Use lib_path_export_script in all soft entries

### DIFF
--- a/module/os/module.py
+++ b/module/os/module.py
@@ -361,8 +361,8 @@ def lib_path_export_script(i):
     """
     Input:  {
               host_os_dict          - host OS meta
-              (dynamic_lib_path)    - dynamic (shared) library path
-              (static_lib_path)     - dynamic (shared) library path
+              (dynamic_lib_path)    - dynamic (shared) library path, or a list of paths
+              (static_lib_path)     - dynamic (shared) library path, or a list of paths
               (lib_path)            - if set, and dynamic_path/static_lib_path is not set, 
                                       uses this value as dynamic_lib_path and/or static_lib_path
             }
@@ -378,8 +378,8 @@ def lib_path_export_script(i):
     """
 
     host_d = i.get('host_os_dict', {})
-    dynamic_path = i.get('dynamic_lib_path', i.get('lib_path', ''))
-    static_path = i.get('static_lib_path', i.get('lib_path', ''))
+    dynamic_path = _convert_lib_path_list_to_string(i.get('dynamic_lib_path', i.get('lib_path', '')))
+    static_path = _convert_lib_path_list_to_string(i.get('static_lib_path', i.get('lib_path', '')))
 
     dynamic_var_name = host_d.get('env_ld_library_path', 'LD_LIBRARY_PATH')
     static_var_name = host_d.get('env_library_path', 'LIBRARY_PATH')
@@ -395,3 +395,6 @@ def lib_path_export_script(i):
       s += '\n'
 
     return {'return': 0, 'script': s}
+
+def _convert_lib_path_list_to_string(lst):
+    return '":"'.join(lst) if isinstance(lst, list) else lst

--- a/module/os/test/test_os.py
+++ b/module/os/test/test_os.py
@@ -82,3 +82,12 @@ class TestOs(unittest.TestCase):
             })
         self.assertEqual(0, r['return'])
         self.assertEqual('', r['script'])
+
+        r = ck.access({
+                'action': 'lib_path_export_script',
+                'module_uoa': 'os',
+                'host_os_dict': {},
+                'lib_path': ['a', 'b']
+            })
+        self.assertEqual(0, r['return'])
+        self.assertEqual('\nexport LD_LIBRARY_PATH="a":"b":$LD_LIBRARY_PATH\nexport LIBRARY_PATH="a":"b":$LIBRARY_PATH\n\n', r['script'])

--- a/soft/compiler.computecpp/customize.py
+++ b/soft/compiler.computecpp/customize.py
@@ -109,6 +109,9 @@ def setup(i):
 
     env[envp]=pp
 
-    s+='export LD_LIBRARY_PATH="'+pl+'":$LD_LIBRARY_PATH\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+      'dynamic_lib_path': pl})
+    if r['return']>0: return r
+    s += r['script']
 
     return {'return':0, 'bat':s, 'env':env, 'tags':tags}

--- a/soft/compiler.cuda/customize.py
+++ b/soft/compiler.cuda/customize.py
@@ -184,8 +184,10 @@ def setup(i):
           if lp!='':
              env[ep+'_LIB']=lp
 
-             s+='export LD_LIBRARY_PATH="'+lp+'":$LD_LIBRARY_PATH\n'
-             s+='export LIBRARY_PATH="'+lp+'":$LIBRARY_PATH\n\n'
+             r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+               'lib_path': lp})
+             if r['return']>0: return r
+             s += r['script']
 
           env[ep+'_INCLUDE']=p2+'/include'
 

--- a/soft/compiler.gcc.android.ndk/customize.py
+++ b/soft/compiler.gcc.android.ndk/customize.py
@@ -284,11 +284,14 @@ def setup(i):
            env['CK_ENV_LIB_CRYSTAX_LIB_FULL_DYNAMIC']=cryf2
 
            if winh=='yes':
+               # TODO: LD_LIBRARY_PATH doesn't work for Windows. Should we remove this if branch, or modify it?
                s+='\nset LD_LIBRARY_PATH='+cry+';%LD_LIBRARY_PATH%\n'
                s+='set LIBRARY_PATH='+cry+';%LIBRARY_PATH%\n'
            else:
-               s+='\nexport LD_LIBRARY_PATH='+cry+':$LD_LIBRARY_PATH\n'
-               s+='export LIBRARY_PATH='+cry+':$LIBRARY_PATH\n'
+               r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+                 'lib_path': cry})
+               if r['return']>0: return r
+               s += r['script']
 
            # Tell ck run to copy extra files via ADB...
            aef=cus.get('adb_extra_files',[])

--- a/soft/compiler.llvm.android.ndk/customize.py.without_gcc
+++ b/soft/compiler.llvm.android.ndk/customize.py.without_gcc
@@ -546,8 +546,10 @@ def setup(i):
             s+='\nset LD_LIBRARY_PATH='+cry+';%LD_LIBRARY_PATH%\n'
             s+='set LIBRARY_PATH='+cry+';%LIBRARY_PATH%\n'
         else:
-            s+='\nexport LD_LIBRARY_PATH='+cry+':$LD_LIBRARY_PATH\n'
-            s+='export LIBRARY_PATH='+cry+':$LIBRARY_PATH\n'
+            r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+              'lib_path': cry})
+            if r['return']>0: return r
+            s += r['script']
 
         # Tell ck run to copy extra files via ADB...
         aef=cus.get('adb_extra_files',[])

--- a/soft/compiler.pencilcc/customize.py
+++ b/soft/compiler.pencilcc/customize.py
@@ -91,7 +91,11 @@ def setup(i):
     env['PRL_LIB_DIR']=cus['path_lib']
     env['PRL_INCLUDE_DIR']=cus['path_include']
 
-    s+='export LD_LIBRARY_PATH='+cus['path_lib']+':$LD_LIBRARY_PATH\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+      'dynamic_lib_path': cus['path_lib']})
+    if r['return']>0: return r
+    s += r['script']
+
     s+='export PATH='+cus['path_bin']+':$PATH\n\n'
 
     return {'return':0, 'bat':s, 'env':env, 'tags':tags}

--- a/soft/lib.boost/customize.py
+++ b/soft/lib.boost/customize.py
@@ -129,8 +129,10 @@ def setup(i):
        cus['path_lib']=p1
        cus['path_include']=os.path.join(pi,'include')
 
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus['path_lib']})
+       if r['return']>0: return r
+       s += r['script']
 
        env[ep+'_LFLAG_SYSTEM']='-lboost_system'
 

--- a/soft/lib.cjson/customize.py
+++ b/soft/lib.cjson/customize.py
@@ -98,11 +98,10 @@ def setup(i):
        sext='.a'
        dext='.so'
 
-    hplat=host_d.get('ck_name','')
-    if hplat!='win':
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     cus['include_name']='cJSON.h'
     cus['static_lib']='libcjson'+sext

--- a/soft/lib.clblas/customize.py
+++ b/soft/lib.clblas/customize.py
@@ -129,9 +129,10 @@ def setup(i):
     cus['path_bin']=os.path.join(pi,'bin')
 
     s+='export PATH='+cus['path_bin']+':$PATH\n'
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.clblast/customize.py
+++ b/soft/lib.clblast/customize.py
@@ -138,9 +138,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.cloog/customize.py
+++ b/soft/lib.cloog/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.cublas/customize.py
+++ b/soft/lib.cublas/customize.py
@@ -219,9 +219,10 @@ def setup(i):
        cus['static_lib']=lb
        cus['dynamic_lib']=lb
 
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='' and ep!='':

--- a/soft/lib.cudnn/customize.py
+++ b/soft/lib.cudnn/customize.py
@@ -219,9 +219,10 @@ def setup(i):
        cus['static_lib']=lb
        cus['dynamic_lib']=lb
 
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='' and ep!='':

--- a/soft/lib.cufft/customize.py
+++ b/soft/lib.cufft/customize.py
@@ -219,9 +219,10 @@ def setup(i):
        cus['static_lib']=lb
        cus['dynamic_lib']=lb
 
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='' and ep!='':

--- a/soft/lib.gflags/customize.py
+++ b/soft/lib.gflags/customize.py
@@ -123,8 +123,10 @@ def setup(i):
        cus['path_lib']=p1
        cus['path_include']=os.path.join(pi,'include')
 
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='' and ep!='':

--- a/soft/lib.glog/customize.py
+++ b/soft/lib.glog/customize.py
@@ -126,8 +126,10 @@ def setup(i):
        cus['path_lib']=p1
        cus['path_include']=os.path.join(pi,'include')
 
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
        env[ep+'_LFLAG']='-lglog'
 

--- a/soft/lib.gmp/customize.py
+++ b/soft/lib.gmp/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.hdf5/customize.py
+++ b/soft/lib.hdf5/customize.py
@@ -156,9 +156,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.isl/customize.py
+++ b/soft/lib.isl/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.mpc/customize.py
+++ b/soft/lib.mpc/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.mpfr/customize.py
+++ b/soft/lib.mpfr/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.ncurses/customize.py
+++ b/soft/lib.ncurses/customize.py
@@ -152,9 +152,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.openblas/customize.py
+++ b/soft/lib.openblas/customize.py
@@ -138,9 +138,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.opencl/customize.py
+++ b/soft/lib.opencl/customize.py
@@ -321,9 +321,10 @@ def setup(i):
        cus['static_lib']=lb
        cus['dynamic_lib']=lb
 
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+       r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+         'lib_path': cus.get('path_lib','')})
+       if r['return']>0: return r
+       s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='' and ep!='':

--- a/soft/lib.opencv/customize.py
+++ b/soft/lib.opencv/customize.py
@@ -205,9 +205,10 @@ def setup(i):
        else:
           s+='\nexport '+ellp+'=$CK_ENV_LIB_OPENCV_LIB:"'+plx+'":$'+ellp+'\n'
 
-
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":"'+plx+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":"'+plx+'":$LIBRARY_PATH\n'
+          r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+            'lib_path': [ cus['path_lib'], plx ] })
+          if r['return']>0: return r
+          s += r['script']
 
     elif win=='yes':
        ext='x64'

--- a/soft/lib.ppl/customize.py
+++ b/soft/lib.ppl/customize.py
@@ -158,9 +158,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.protobuf.host/customize.py
+++ b/soft/lib.protobuf.host/customize.py
@@ -130,9 +130,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.protobuf/customize.py
+++ b/soft/lib.protobuf/customize.py
@@ -130,9 +130,10 @@ def setup(i):
     cus['static_lib']=lbs
     cus['dynamic_lib']=lb
 
-    if cus.get('path_lib','')!='':
-       s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-       s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': hosd, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     ep=cus.get('env_prefix','')
     if pi!='':

--- a/soft/lib.viennacl/customize.py
+++ b/soft/lib.viennacl/customize.py
@@ -97,11 +97,10 @@ def setup(i):
        sext='.a'
        dext='.so'
 
-    hplat=host_d.get('ck_name','')
-    if hplat!='win':
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
-          s+='export LIBRARY_PATH="'+cus['path_lib']+'":$LIBRARY_PATH\n\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+      'lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     cus['include_name']='viennacl.h'
     cus['static_lib']='libviennacl'+sext

--- a/soft/plugin.openme.ctuning/customize.py
+++ b/soft/plugin.openme.ctuning/customize.py
@@ -93,10 +93,10 @@ def setup(i):
     else:
        dext='.so'
 
-    hplat=host_d.get('ck_name','')
-    if hplat!='win':
-       if cus.get('path_lib','')!='':
-          s+='export LD_LIBRARY_PATH="'+cus['path_lib']+'":$LD_LIBRARY_PATH\n'
+    r = ck.access({'action': 'lib_path_export_script', 'module_uoa': 'os', 'host_os_dict': host_d, 
+      'dynamic_lib_path': cus.get('path_lib','')})
+    if r['return']>0: return r
+    s += r['script']
 
     cus['dynamic_plugin']='plugin-openme-ctuning-1.5'+dext
 


### PR DESCRIPTION
Hi, 

This PR uses `lib_path_export_script` instead of raw `LD_LIBRARY_PATH` in all soft entries. It also enhances `lib_path_export_script` so it can accept lists of paths in addition to a single one (a test for that is also added).