### PR TITLE
Increase compiler.python search depth to 6

### DIFF
--- a/soft/compiler.microsoft/customize.py
+++ b/soft/compiler.microsoft/customize.py
@@ -95,7 +95,6 @@ def parse_version(i):
               if j2>=0:
                  ver=q[:j2]
                  break
-    
     return {'return':0, 'version':ver}
 
 ##############################################################################

--- a/soft/compiler.python/.cm/meta.json
+++ b/soft/compiler.python/.cm/meta.json
@@ -11,7 +11,7 @@
     ], 
     "limit_recursion_dir_search": {
       "linux": 3, 
-      "win": 4
+      "win": 6
     }, 
     "only_for_host_os_tags": [
       "windows", 

--- a/soft/compiler.python/.cm/meta.json
+++ b/soft/compiler.python/.cm/meta.json
@@ -11,7 +11,7 @@
     ], 
     "limit_recursion_dir_search": {
       "linux": 3, 
-      "win": 6
+      "win": 4
     }, 
     "only_for_host_os_tags": [
       "windows", 

--- a/soft/compiler.python/customize.py
+++ b/soft/compiler.python/customize.py
@@ -17,6 +17,13 @@ def dirs(i):
 
     ck_os_name=i.get('host_os_dict',{}).get('ck_name','')
     if ck_os_name=='win':
+       local_app_data = os.getenv('LOCALAPPDATA')
+       if local_app_data is not None:
+          dr.append(local_app_data)
+
+       roaming_app_data = os.getenv('APPDATA')
+       if roaming_app_data is not None:
+          dr.append(roaming_app_data)
 
        for px in ['C:\\', 'D:\\']:
            x=[]


### PR DESCRIPTION
Hi,

This PR increases compiler.python search depth to 6. Typical python installation path for Windows (if installed just for one user) is `C:\Users\USERNAME\AppData\Local\Programs\Python\Python36-32`. With depth level 4, CK was not able to find this path.