### PR TITLE
Add CL kernels directory to lib-acl env

### DIFF
--- a/soft/lib.acl/customize.py
+++ b/soft/lib.acl/customize.py
@@ -105,7 +105,7 @@ def setup(i):
        env[ep+'_TESTS']=ptests
        cus['path_includes'].append(ptests)
 
-    pkernels=os.path.join(os.path.dirname(pi),'src/src/core/CL/cl_kernels')
+    pkernels=os.path.join(os.path.dirname(pi),'src/src/core/CL/cl_kernels/')
     if os.path.isdir(pkernels):
        env[ep+'_CL_KERNELS']=pkernels
        cus['path_includes'].append(pkernels)

--- a/soft/lib.acl/customize.py
+++ b/soft/lib.acl/customize.py
@@ -108,7 +108,6 @@ def setup(i):
     pkernels=os.path.join(os.path.dirname(pi),'src/src/core/CL/cl_kernels/')
     if os.path.isdir(pkernels):
        env[ep+'_CL_KERNELS']=pkernels
-       cus['path_includes'].append(pkernels)
 
     ################################################################
     if win=='yes':

--- a/soft/lib.acl/customize.py
+++ b/soft/lib.acl/customize.py
@@ -105,6 +105,11 @@ def setup(i):
        env[ep+'_TESTS']=ptests
        cus['path_includes'].append(ptests)
 
+    pkernels=os.path.join(os.path.dirname(pi),'src/src/core/CL/cl_kernels')
+    if os.path.isdir(pkernels):
+       env[ep+'_CL_KERNELS']=pkernels
+       cus['path_includes'].append(pkernels)
+
     ################################################################
     if win=='yes':
        if remote=='yes' or mingw=='yes':


### PR DESCRIPTION
Hi,

This PR adds CL kernels directory to lib-acl env as `CK_ENV_LIB_ACL_CL_KERNELS` var. This is needed so that if the lib is built without embedded kernels, programs may use this variable to access them.