### PR TITLE
Fix set_freq failing when using adb and CK_CPU envs. Current the scri…

### DIFF
--- a/module/platform.cpu/module.py
+++ b/module/platform.cpu/module.py
@@ -922,7 +922,7 @@ def set_freq(i):
           dv=''
           if tdid!='': dv=' -s '+tdid
 
-          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' '+cmd
+          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' "'+cmd+'"'
 
           rx=os.system(x)
           if rx!=0:

--- a/module/platform.gpu/module.py
+++ b/module/platform.gpu/module.py
@@ -636,7 +636,7 @@ def set_freq(i):
           dv=''
           if tdid!='': dv=' -s '+tdid
 
-          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' '+cmd
+          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' "'+cmd+'"'
 
           rx=os.system(x)
           if rx!=0:


### PR DESCRIPTION
…pts fail to execute when the envs are prefixed on the command.

More details:
Running a pipeline on an android target with --env.CK_CPU0_ONLINE=1 --cpu_freq=max fails to run the ck-set-cpu-performance script. The command it generates is:
adb  -s 10.10.4.164:5555 shell export  CK_CPU0_ONLINE=0;export  CK_CPU1_ONLINE=0;export  CK_CPU2_ONLINE=0;export  CK_CPU3_ONLINE=0;export  CK_CPU4_ONLINE=1;export  CK_CPU5_ONLINE=1;export  CK_CPU6_ONLINE=1;export  CK_CPU7_ONLINE=1;export  CK_CPU_FREQUENCY=max;/data/local/tmp/tools/ck-set-cpu-performance
this returns:
sh: 1: /data/local/tmp/tools/ck-set-cpu-performance: not found

The script exists on the remote machine. I think the solution is to wrap the command in quotes.