### PR TITLE
Allow LLVM compiler to be correctly detected and used on MacOSX

### DIFF
--- a/soft/compiler.llvm/customize.py
+++ b/soft/compiler.llvm/customize.py
@@ -443,6 +443,10 @@ def setup(i):
        elif mac=='yes':
           env["CK_LB"]="$#tool_prefix#$ar -rcs"
           env["CK_LB_OUTPUT"]=""
+          env["CK_AR_PATH_FOR_CMAKE"]       = pi + sdirs + 'bin' + sdirs + 'llvm-ar'
+          env["CK_RANLIB_PATH_FOR_CMAKE"]   = pi + sdirs + 'bin' + sdirs + 'llvm-ranlib'
+          env["CK_EXTRA_MISC_CXX_FLAGS"]    = '-L' + pi + sdirs + 'lib' + ' -stdlib=libstdc++'
+          env["CK_DLL_EXT"]                 = '.dylib'
        else:
           env["CK_LB"]="$#tool_prefix#$ar rcs"
           env["CK_LB_OUTPUT"]="-o "


### PR DESCRIPTION
(1) Because LLVM brings along its own ar/runlib replacements, they have to be enforced
to avoid collision with the potentially incompatible default versions.

(2) LLVM has switched to using libstdc++ instead of libc++ by default, but for compatibility
with objects compiled separately we need to restore the previous behaviour.

(3) Several shell scripts need to be passed .dylib as the filename suffix for dynamically-linked libraries.
An existing variable CK_DLL_EXT is (re-)used for this purpose.