### PR TITLE
Support the correct detection of more libraries under MacOSX

### DIFF
--- a/soft/lib.boost/.cm/meta.json
+++ b/soft/lib.boost/.cm/meta.json
@@ -9,7 +9,7 @@
       "win": 4
     }, 
     "soft_file": {
-      "linux": "libboost_system$#file_ext_dll#$", 
+      "linux": "libboost_system$#file_ext_dll#$",
       "win": "libboost_system*-mt*$#file_ext_lib#$"
     }, 
     "soft_path_example": {

--- a/soft/lib.gflags/.cm/meta.json
+++ b/soft/lib.gflags/.cm/meta.json
@@ -9,7 +9,7 @@
       "win": 3
     },
     "soft_file": {
-      "linux": "libgflags.so",
+      "linux": "libgflags$#file_ext_dll#$",
       "win": "gflags.lib"
     },
     "soft_path_example": {

--- a/soft/lib.glog/.cm/meta.json
+++ b/soft/lib.glog/.cm/meta.json
@@ -9,7 +9,7 @@
       "win": 3
     },
     "soft_file": {
-      "linux": "libglog.so",
+      "linux": "libglog$#file_ext_dll#$",
       "win": "glog.lib"
     },
     "soft_path_example": {

--- a/soft/lib.hdf5/.cm/meta.json
+++ b/soft/lib.hdf5/.cm/meta.json
@@ -9,7 +9,7 @@
       "linux": 6
     }, 
     "soft_file": {
-      "linux": "libhdf5.so"
+      "linux": "libhdf5$#file_ext_dll#$"
     }, 
     "soft_path_example": {
       "linux": "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so"

--- a/soft/lib.lmdb/.cm/meta.json
+++ b/soft/lib.lmdb/.cm/meta.json
@@ -9,7 +9,7 @@
       "win": 3
     },
     "soft_file": {
-      "linux": "liblmdb.so",
+      "linux": "liblmdb$#file_ext_dll#$",
       "win": "lmdb.lib"
     },
     "soft_path_example": {

--- a/soft/lib.openblas/.cm/meta.json
+++ b/soft/lib.openblas/.cm/meta.json
@@ -9,7 +9,7 @@
       "linux": 3
     }, 
     "soft_file": {
-      "linux": "libopenblas.so"
+      "linux": "libopenblas$#file_ext_dll#$"
     }, 
     "soft_path_example": {
       "linux": "/usr/lib/libopenblas.so"

--- a/soft/lib.opencv/.cm/meta.json
+++ b/soft/lib.opencv/.cm/meta.json
@@ -9,7 +9,7 @@
       "win": 5
     }, 
     "soft_file": {
-      "linux": "libopencv_core.so",
+      "linux": "libopencv_core$#file_ext_dll#$",
       "win": "opencv_annotation.exe"
     }, 
     "soft_path_example": {


### PR DESCRIPTION
This support was started by Grigori in 5c78c81df078c4aef3e6ac4dfda57cf9038b1f37 ,
where it was used for detection of lib.boost.
Here I am merely extending it to the libraries involved in compilation of Caffe.