### PR TITLE
bugfix: the product of protobuf compilation is a static .a library

### DIFF
--- a/soft/lib.protobuf.host/.cm/meta.json
+++ b/soft/lib.protobuf.host/.cm/meta.json
@@ -8,7 +8,7 @@
       "linux": 3
     },
     "soft_file": {
-      "linux": "libprotobuf.so"
+      "linux": "libprotobuf.a"
     },
     "soft_path_example": {
       "linux": ""

--- a/soft/lib.protobuf/.cm/meta.json
+++ b/soft/lib.protobuf/.cm/meta.json
@@ -8,7 +8,7 @@
       "linux": 3
     },
     "soft_file": {
-      "linux": "libprotobuf.so"
+      "linux": "libprotobuf.a"
     },
     "soft_path_example": {
       "linux": ""


### PR DESCRIPTION
Fixed the corresponding meta.json files

Tested this both on Ubuntu and MacOSX: CK's default compilation route copies just 3 files into install/lib :
    libprotobuf-lite.a
    libprotobuf.a
    libprotoc.a