### PR TITLE
Packages that produce dynamic libraries under MacOSX should also respect…

### DIFF
--- a/module/package/module.py
+++ b/module/package/module.py
@@ -1081,6 +1081,17 @@ def install(i):
           x=x.replace('$#sep#$', sdirs)
           x=x.replace('$#abi#$', tosd.get('abi',''))
           x=x.replace('$#processor#$', tosd.get('processor',''))
+
+            # NOTE: adapted from module/soft/module.py/prepare_target_name()
+            #       After successful testing this function should be moved out
+            #       into a common utility space and imported from there.
+            #       Also, check whether the original function was supposed to be
+            #           sourcing the data from hosd or tosd.
+          file_extensions=tosd.get('file_extensions',{})
+          for k in file_extensions:
+              v=file_extensions[k]
+              x=x.replace('$#file_ext_'+k+'#$',v)
+
           fp=os.path.join(fp,x)
           if os.path.isfile(fp):
              if o=='con':

--- a/package/lib-glog-0.3.5/.cm/meta.json
+++ b/package/lib-glog-0.3.5/.cm/meta.json
@@ -42,8 +42,8 @@
     }
   }, 
   "end_full_path": {
-    "android": "install$#sep#$lib$#sep#$libglog.a", 
-    "linux": "install/lib/libglog.so", 
+    "android": "install$#sep#$lib$#sep#$libglog.a",
+    "linux": "install/lib/libglog$#file_ext_dll#$",
     "win": "install\\lib\\glog.lib"
   }, 
   "need_cpu_info": "yes", 

--- a/package/lib-glog-trunk/.cm/meta.json
+++ b/package/lib-glog-trunk/.cm/meta.json
@@ -42,7 +42,7 @@
   },
   "end_full_path": {
     "android": "install$#sep#$lib$#sep#$libglog.a",
-    "linux": "install/lib/libglog.so",
+    "linux": "install/lib/libglog$#file_ext_dll#$",
     "win": "install\\lib\\glog.lib"
   },
   "need_cpu_info": "yes",

--- a/package/lib-hdf5-1.10.0-src/.cm/meta.json
+++ b/package/lib-hdf5-1.10.0-src/.cm/meta.json
@@ -45,7 +45,7 @@
     }
   },
   "end_full_path": {
-    "linux": "install/lib/libhdf5.so",
+    "linux": "install/lib/libhdf5$#file_ext_dll#$",
     "win": "install\\lib\\libhdf5.lib"
   },
   "need_cpu_info": "yes",

--- a/package/lib-hdf5-1.10.1-src/.cm/meta.json
+++ b/package/lib-hdf5-1.10.1-src/.cm/meta.json
@@ -45,7 +45,7 @@
     }
   },
   "end_full_path": {
-    "linux": "install/lib/libhdf5.so",
+    "linux": "install/lib/libhdf5$#file_ext_dll#$",
     "win": "install\\lib\\libhdf5.lib"
   },
   "need_cpu_info": "yes",

--- a/package/lib-hdf5-1.8.18-src/.cm/meta.json
+++ b/package/lib-hdf5-1.8.18-src/.cm/meta.json
@@ -45,7 +45,7 @@
     }
   }, 
   "end_full_path": {
-    "linux": "install/lib/libhdf5.so", 
+    "linux": "install/lib/libhdf5$#file_ext_dll#$",
     "win": "install\\lib\\libhdf5.lib"
   }, 
   "need_cpu_info": "yes", 


### PR DESCRIPTION
… the .so/.dylib difference

I've adapted a chunk of the code from module/soft/module.py/prepare_target_name()
that was previously used for soft entries.  The difference is that in this case
I believe we should be dealing with *target* system's parameters coming from tosd.

However I wonder if the same could be true for the original prepare_target_name() -
i.e. shouldn't is be using tosd instead of hosd?
Has this been tested in cross-compilation context?
