### PR TITLE
To correctly compile LMDB under MacOSX extra parameters have to be passed to make

### DIFF
--- a/package/lib-lmdb-master-universal/scripts.linux/install.sh
+++ b/package/lib-lmdb-master-universal/scripts.linux/install.sh
@@ -19,7 +19,15 @@ cd ${INSTALL_DIR}/src/libraries/liblmdb
 echo ""
 echo "Building package ..."
 
-make -j${CK_HOST_CPU_NUMBER_OF_PROCESSORS} CC="${CK_CC} ${CK_COMPILER_FLAGS_OBLIGATORY}" AR="${CK_AR}" XCFLAGS="-DMDB_DSYNC=O_SYNC -DMDB_USE_ROBUST=0"
+    # on a Mac and compiling with LLVM:
+if [ "$CK_DLL_EXT" = ".dylib" ] && [ "$CK_CC" = "clang" ]
+then
+    MAKE_SOLIBS=" -install_name @rpath/liblmdb.dylib "
+else
+    MAKE_SOLIBS=""
+fi
+
+make -j${CK_HOST_CPU_NUMBER_OF_PROCESSORS} CC="${CK_CC} ${CK_COMPILER_FLAGS_OBLIGATORY}" AR="${CK_AR}" XCFLAGS="-DMDB_DSYNC=O_SYNC -DMDB_USE_ROBUST=0" SOEXT="${CK_DLL_EXT}" SOLIBS="${MAKE_SOLIBS}"
 if [ "${?}" != "0" ] ; then
   echo "Error: build failed!"
   exit 1
@@ -29,7 +37,7 @@ fi
 echo ""
 echo "Installing package ..."
 
-make prefix="${INSTALL_DIR}/install" install
+make prefix="${INSTALL_DIR}/install" SOEXT="${CK_DLL_EXT}" install
 if [ "${?}" != "0" ] ; then
   echo "Error: installation failed!"
   exit 1


### PR DESCRIPTION
(1) CK_DLL_EXT should (after commit ba3e9f5aa4bb55aad399e76f5edd8683f90e5569 ) contain the correct filename suffix of the dynamic library.

(2) In order to make the dynamic library discoverable under MacOSX we have to tweak its "install_name"   by adding "@rpath" as it is done automatically for all other cmake-generated libraries.
 Clang now supports a special command line option -install_name that is correctly ignored on Ubuntu.