### PR TITLE
Automatic detection of software installed using 'brew' under OSX

### DIFF
--- a/module/soft/module.py
+++ b/module/soft/module.py
@@ -1591,6 +1591,16 @@ def check(i):
        x='/opt'
        if os.path.isdir(x) and x not in dirs:
           dirs.append(x)
+       #
+       # FIXME: Currently treating OSX as a subset of Linux:
+       #
+       if hosd.get('macos'):
+          #
+          # The location of software installed by brew prior to softlinking:
+          #
+          x='/usr/local/Cellar'
+          if os.path.isdir(x) and x not in dirs:
+             dirs.append(x)
 
     # Add from CK_TOOLS env
     x=os.environ.get(env_install_path,'')


### PR DESCRIPTION
Although brew's location /usr/local/Cellar is under standard /usr
that is already supported, the file trees are usually quite deep,
slightly out of reach of the existing recursive search_tool method
with the default depths ('limit_recursion_dir_search/linux') of 3 or 4.

Increasing this depth by brute force for all 'linux' cases would lead
to very long search times on the platform that should not be affected.
It would also mean changing all soft entries across the project.

So I'm opting to introduce another branch into this decision tree.