### PR TITLE
Change version detection mechanism for Python OpenCV

### DIFF
--- a/soft/lib.python.cv2/.cm/meta.json
+++ b/soft/lib.python.cv2/.cm/meta.json
@@ -8,8 +8,8 @@
       "win": 5
     },
     "soft_file_universal": "cv2$#sep#$__init__.py",
-    "detect_version_externally": "yes",
-    "version_variable_name": "__version__"
+    "version_module_name": "version",
+    "version_variable_name": "opencv_version"
   },
   "soft_name": "Python OpenCV library",
   "tags": [

--- a/soft/lib.python.cv2/README.txt
+++ b/soft/lib.python.cv2/README.txt
@@ -1,0 +1,14 @@
+Supported automatic version detection starts from 4.3.0.38 onwards.
+
+
+If you need to detect an earlier version, please create a version.py file
+in the corresponding cv2/ directory with a single line:
+------------->8--cut-here--8<-----------
+opencv_version = "x.y.z.p"
+------------->8--cut-here--8<-----------
+where x.y.z.p is your desired version.
+
+
+When installing older OpenCV versions please use --force_version:
+    ck install package --tags=lib,python-package,cv2 --force_version=4.0.0.21
+This will skip version detection.


### PR DESCRIPTION
For recent OpenCV versions, it is preferable to parse the package version from `version.py`. Older versions can still be supported with a simple workaround described in `README`.