### PR TITLE
Improve consistency of remote_shell start and end

### DIFF
--- a/module/platform.cpu/module.py
+++ b/module/platform.cpu/module.py
@@ -860,6 +860,8 @@ def set_freq(i):
     dir_sep=tosd.get('dir_sep','')
 
     remote=tosd.get('remote','')
+    rs=tosd.get('remote_shell','')
+    rse=tosd.get('remote_shell_end','')
 
     # Prepare scripts
     cmd=''
@@ -927,7 +929,9 @@ def set_freq(i):
           dv=''
           if tdid!='': dv=' -s '+tdid
 
-          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' "'+cmd+'"'
+          x=rs.replace('$#device#$',dv)
+          # Support backwards compatibility if double quote not found in rs and rse
+          x+=('"' if rs.find('"') == -1 else '')+' '+cmd+' '+rse+('"' if rse.find('"') == -1 else '')
 
           rx=os.system(x)
           if rx!=0:

--- a/module/platform.gpu/module.py
+++ b/module/platform.gpu/module.py
@@ -570,6 +570,8 @@ def set_freq(i):
     dir_sep=tosd.get('dir_sep','')
 
     remote=tosd.get('remote','')
+    rs=tosd.get('remote_shell','')
+    rse=tosd.get('remote_shell_end','')
 
     # Prepare scripts
     cmd=''
@@ -636,7 +638,9 @@ def set_freq(i):
           dv=''
           if tdid!='': dv=' -s '+tdid
 
-          x=tosd.get('remote_shell','').replace('$#device#$',dv)+' "'+cmd+'"'
+          x=rs.replace('$#device#$',dv)
+          # Support backwards compatibility if double quote not found in rs and rse
+          x+=('"' if rs.find('"') == -1 else '')+' '+cmd+' '+rse+('"' if rse.find('"') == -1 else '')
 
           rx=os.system(x)
           if rx!=0:


### PR DESCRIPTION
CPU and GPU frequency setting only called remote_shell and not remote_shell_end.
This left some commands unquoted if quotes were present in both remote_shell and
remote_shell_end. Implementation is not as tidy as other cmd calls as I wanted
to preserve backwards compatibility. If not, all targets would require
remote_shell and remote_shell_end to contain quotes to ensure cmds were
correctly executed on the remote targets.

The situation that I found myself in was:
+ Using a linux remote target with access type ssh
+ The detect function in platform.os (ck-env/module/platform.os/module.py)
  performs a chmod where the string required remote_shell and remote_shell_end
  to have quotes. Otherwise the command was executed incorrectly
+ Adding quotes to remote_shell and remote_shell_end fixed the above issue but
  platform.cpu and platform.gpu set_freq functions created a cmd which had
  three quotes producing and error.